### PR TITLE
+ seaweedfs: #PPF-10524 Проверка существования объекта в readNeedle при конкурентном обращении [2/2];

### DIFF
--- a/weed/storage/volume_read.go
+++ b/weed/storage/volume_read.go
@@ -2,9 +2,10 @@ package storage
 
 import (
 	"fmt"
-	"github.com/Infowatch/seaweedfs/weed/util/mem"
 	"io"
 	"time"
+
+	"github.com/Infowatch/seaweedfs/weed/util/mem"
 
 	"github.com/Infowatch/seaweedfs/weed/glog"
 	"github.com/Infowatch/seaweedfs/weed/storage/backend"
@@ -19,6 +20,13 @@ const PagedReadLimit = 1024 * 1024
 func (v *Volume) readNeedle(n *needle.Needle, readOption *ReadOption, onReadSizeFn func(size Size)) (count int, err error) {
 	v.dataFileAccessLock.RLock()
 	defer v.dataFileAccessLock.RUnlock()
+
+	// По-скольку одновременно могут приходить запросы на модификацию для этого же needle, важно сразу же возвращать
+	// ошибку на верхний уровень, иначе могут возникать непредвиденные ситуации как в PPF-10524,11001
+	// Конкретно в методе doClose: nm, DataBackend становятся nil и в других потоках при обращении к ним возникают паники (nil ptr deref)
+	if v.nm == nil || v.DataBackend == nil {
+		return -1, ErrNotReady
+	}
 
 	nv, ok := v.nm.Get(n.Id)
 	if !ok || nv.Offset.IsZero() {

--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -15,6 +15,7 @@ import (
 var ErrorNotFound = errors.New("not found")
 var ErrorDeleted = errors.New("already deleted")
 var ErrorSizeMismatch = errors.New("size mismatch")
+var ErrNotReady = errors.New("not ready")
 
 func (v *Volume) checkReadWriteError(err error) {
 	if err == nil {


### PR DESCRIPTION
• Если параллельно удаляются иголки, будет вызван doClose метод, в котором поля Volume становятся nil. При следующем обращении к ним в другом потоке происходит nil pointer deref (panic).